### PR TITLE
[569851] The Filtering criteria decoration layer is activated on new diagrams

### DIFF
--- a/plugins/org.polarsys.capella.filtering.sirius.analysis/description/FilteringResults.odesign
+++ b/plugins/org.polarsys.capella.filtering.sirius.analysis/description/FilteringResults.odesign
@@ -74,7 +74,7 @@
       </filters>
     </ownedRepresentations>
     <ownedRepresentationExtensions xsi:type="description_2:DiagramExtensionDescription" name="FilteringDiagExtension" viewpointURI="viewpoint:/org.polarsys.capella.core.sirius.analysis/.*" representationName=".*">
-      <layers name="Filtering Criteria Decoration" activeByDefault="true">
+      <layers name="Filtering Criteria Decoration">
         <decorationDescriptionsSet>
           <decorationDescriptions xsi:type="description:GenericDecorationDescription" name="HasAssociatedFilteringCriteria" position="NORTH_EAST" distributionDirection="HORIZONTAL" preconditionExpression="service:view.hasDecorationPLText" imageExpression="/org.polarsys.capella.filtering.sirius.analysis/icons/optionalDecorator.png"/>
         </decorationDescriptionsSet>


### PR DESCRIPTION
Bug: 569851
Change-Id: I81c50f6c9626557cb07994451df1304da8af16c7
Signed-off-by: Tu Ton <minhtutonthat@gmail.com>