### PR TITLE
[releng] build on Capella 5.2.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
 	environment {
 		BUILD_KEY = (github.isPullRequest() ? CHANGE_TARGET : BRANCH_NAME).replaceFirst(/^v/, '')
 		CAPELLA_PRODUCT_PATH = "${WORKSPACE}/capella/capella"
-		CAPELLA_BRANCH = 'master'
+		CAPELLA_BRANCH = '5.x'
   	}
   
   	stages {

--- a/releng/org.polarsys.capella.filtering.update/capella.target-definition.targetplatform
+++ b/releng/org.polarsys.capella.filtering.update/capella.target-definition.targetplatform
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,17 +12,17 @@
  *******************************************************************************/
 target "CapellaFiltering"
 
-include "https://raw.githubusercontent.com/eclipse/capella/master/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform"
+include "https://download.eclipse.org/capella/core/updates/releases/5.2.0-R20211130-125709/targets/capella.target-definition.targetplatform"
 
 with source, requirements
 
-location capella-core "https://download.eclipse.org/capella/core/updates/nightly/master/org.polarsys.capella.rcp.site" {
+location capella-core "https://download.eclipse.org/capella/core/updates/releases/5.2.0-R20211130-125709/org.polarsys.capella.rcp.site" {
 
 	org.polarsys.capella.rcp.feature.group
 	org.polarsys.capella.cdo.mock.feature.feature.group
 }
 
-location capella-tests "https://download.eclipse.org/capella/core/updates/nightly/master/org.polarsys.capella.test.site" {
+location capella-tests "https://download.eclipse.org/capella/core/updates/releases/5.2.0-R20211130-125709/org.polarsys.capella.test.site" {
 
 	org.polarsys.capella.test.feature.feature.group
 }


### PR DESCRIPTION
Modification required to get a build using Capella 5.2.0 to execute the tests: current test failures are "migration required" when there is no need to migrate the test models as they are already in version 5.2.0.