### PR TITLE
#73 Added default filename for export dialog

### DIFF
--- a/plugins/org.polarsys.capella.filtering.tools/src/org/polarsys/capella/filtering/tools/Messages.java
+++ b/plugins/org.polarsys.capella.filtering.tools/src/org/polarsys/capella/filtering/tools/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,6 +30,9 @@ public class Messages extends NLS {
 
   public static String filtering_dialog_title;
   public static String filtering_dialog_msg;
+  
+  public static String filtering_overview_dialog_default_filename;
+  public static String filtering_metrics_dialog_default_filename;
 
   public static String filtering_dialog_combo_lbl;
   public static String filtering_dialog_combo_allStatus;

--- a/plugins/org.polarsys.capella.filtering.tools/src/org/polarsys/capella/filtering/tools/dialogs/FilteringMetricsDialog.java
+++ b/plugins/org.polarsys.capella.filtering.tools/src/org/polarsys/capella/filtering/tools/dialogs/FilteringMetricsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -231,5 +231,9 @@ public class FilteringMetricsDialog extends AbstractExportDialog {
 
     return result;
   }
-
+  
+  @Override
+  protected String getDefaultFileName() {
+    return Messages.filtering_metrics_dialog_default_filename;
+  }
 }

--- a/plugins/org.polarsys.capella.filtering.tools/src/org/polarsys/capella/filtering/tools/dialogs/FilteringOverviewDialog.java
+++ b/plugins/org.polarsys.capella.filtering.tools/src/org/polarsys/capella/filtering/tools/dialogs/FilteringOverviewDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -212,5 +212,10 @@ public class FilteringOverviewDialog extends AbstractExportDialog {
     }
 
     return result;
+  }
+  
+  @Override
+  protected String getDefaultFileName() {
+    return Messages.filtering_overview_dialog_default_filename;
   }
 }

--- a/plugins/org.polarsys.capella.filtering.tools/src/org/polarsys/capella/filtering/tools/messages.properties
+++ b/plugins/org.polarsys.capella.filtering.tools/src/org/polarsys/capella/filtering/tools/messages.properties
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018 THALES GLOBAL SERVICES.
+# Copyright (c) 2018, 2023 THALES GLOBAL SERVICES.
 # 
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,9 @@ filtering_overviewAction_lbl=Analyze element Filtering Criteria
 
 filtering_dialog_title=Filtering Overview
 filtering_dialog_msg=Display the objects with a Filtering Criterion
+
+filtering_overview_dialog_default_filename=filtering_overview;
+filtering_metrics_dialog_default_filename=filtering metrics;
 
 filtering_dialog_combo_lbl=Select Filtering Criterion:
 filtering_dialog_combo_allStatus=All Filtering Criteria


### PR DESCRIPTION
Default filename were added in metrics export and overview export Their values are respectively "filtering_metrics" (default to filtering_metrics.csv) and "filtering_overview" (default to filtering_overview.csv)

Change-Id: I2aff217ba714e499732e986f277d936a8cca75c4
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>